### PR TITLE
Add Java classpath to Flyway locations

### DIFF
--- a/miso-ansible/files/miso-install.sh
+++ b/miso-ansible/files/miso-install.sh
@@ -11,4 +11,4 @@ cd ${FLYWAY}
 rm -f lib/sqlstore-*.jar
 unzip -xjo /var/lib/tomcat8/webapps/ROOT.war 'WEB-INF/lib/sqlstore-*.jar' -d lib
 /etc/init.d/mysql start
-./flyway -user=$MISO_DB_USER -password=$MISO_DB_PASS -url=$MISO_DB_URL -outOfOrder=true -locations=classpath:db/migration migrate
+./flyway -user=$MISO_DB_USER -password=$MISO_DB_PASS -url=$MISO_DB_URL -outOfOrder=true -locations=classpath:db/migration,classpath:uk.ac.bbsrc.tgac.miso.db.migration migrate


### PR DESCRIPTION
Allows Flyway to find and handle Java migrations when building the MISO container.