### PR TITLE
Fix error where MySQL 5.7 does not start on some machines

### DIFF
--- a/miso-ansible/files/miso-install.sh
+++ b/miso-ansible/files/miso-install.sh
@@ -11,4 +11,4 @@ cd ${FLYWAY}
 rm -f lib/sqlstore-*.jar
 unzip -xjo /var/lib/tomcat8/webapps/ROOT.war 'WEB-INF/lib/sqlstore-*.jar' -d lib
 /etc/init.d/mysql start
-./flyway -user=$MISO_DB_USER -password=$MISO_DB_PASS -url=$MISO_DB_URL -outOfOrder=true -locations=classpath:db/migration,classpath:uk.ac.bbsrc.tgac.miso.db.migration migrate
+./flyway -user=$MISO_DB_USER -password=$MISO_DB_PASS -url=$MISO_DB_URL -outOfOrder=true -locations=classpath:db/migration,classpath:uk.ac.bbsrc.tgac.miso.db.migration -placeholders.filesDir=/storage/miso/files/ migrate

--- a/miso-ansible/miso.yml
+++ b/miso-ansible/miso.yml
@@ -56,7 +56,7 @@
 
     - name: download jndi-file-factory
       get_url: >
-        url=http://hasbanana.co.uk/maven/repo/uk/ac/ebi/fgpt/jndi-file-factory/1.0/jndi-file-factory-1.0.jar
+        url=https://repos.tgac.ac.uk/miso/common/jndi-file-factory-1.0.jar
         dest=/var/lib/tomcat8/lib/
         owner=tomcat8
         group=tomcat8

--- a/miso-ansible/misoStart.sh
+++ b/miso-ansible/misoStart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Inspired by http://stackoverflow.com/questions/24265354/tomcat7-in-debianwheezy-docker-instance-fails-to-start
+# Also by: https://github.com/docker/for-linux/issues/72
 
+find /var/lib/mysql -type f -exec touch {} \;
 /etc/init.d/mysql start
 /etc/init.d/tomcat8 start
 


### PR DESCRIPTION
As per [this issue](https://github.com/TGAC/miso-lims/issues/1803)
This has to do with the Docker setup on the host machine. If it uses the `overlay2` storage driver, MySQL is unable to start. (See [link](https://github.com/docker/for-linux/issues/72) for more info)
```
$ docker info
Storage Driver: overlay2
```
Once this is merged, I'd like to build, tag, and push image `0.6`.